### PR TITLE
feat(routes): expose OTLP write paths for Mimir and Loki

### DIFF
--- a/helm/observability-platform-api/templates/route-loki-write.yaml
+++ b/helm/observability-platform-api/templates/route-loki-write.yaml
@@ -5,11 +5,14 @@ Resources:
   - HTTPRoute: routes write requests to loki-gateway:80 in loki.namespace.
     Rule 1: matches /loki/api/v1/push + X-Scope-OrgID header → forwards to backend.
     Rule 2: matches /loki/api/v1/push only (no header) → returns 401 via HTTPRouteFilter.
+    Rule 3: matches /otlp/v1/logs + X-Scope-OrgID header → forwards to backend (no rewrite).
+    Rule 4: matches /otlp/v1/logs only (no header) → returns 401 via HTTPRouteFilter.
   - SecurityPolicy: enforces JWT validation using auth.jwt.providers.
   - HTTPRouteFilter: returns 401 when X-Scope-OrgID header is missing.
 
 Exposed paths:
   /loki/api/v1/push
+  /otlp/v1/logs    (forwarded as-is; nginx gateway proxies to Loki OTLP ingest)
 */}}
 {{- if and .Values.loki.enabled .Values.auth.jwt.providers -}}
 ---
@@ -62,6 +65,38 @@ spec:
     - path:
         type: PathPrefix
         value: /loki/api/v1/push
+  - backendRefs:
+    - name: loki-gateway
+      namespace: {{ .Values.loki.namespace }}
+      port: 80
+    matches:
+    - path:
+        type: PathPrefix
+        value: /otlp/v1/logs
+      headers:
+      - name: X-Scope-OrgID
+        value: "^.+$"
+        type: RegularExpression
+    filters:
+    - type: ResponseHeaderModifier
+      responseHeaderModifier:
+        set:
+        - name: X-Scope-OrgID
+          value: "%REQ(X-Scope-OrgID)%"
+  - backendRefs:
+    - name: loki-gateway
+      namespace: {{ .Values.loki.namespace }}
+      port: 80
+    filters:
+    - type: ExtensionRef
+      extensionRef:
+        group: gateway.envoyproxy.io
+        kind: HTTPRouteFilter
+        name: {{ include "resource.default.name" . }}-loki-write-api-headers-check
+    matches:
+    - path:
+        type: PathPrefix
+        value: /otlp/v1/logs
 ---
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: SecurityPolicy

--- a/helm/observability-platform-api/templates/route-mimir-write.yaml
+++ b/helm/observability-platform-api/templates/route-mimir-write.yaml
@@ -6,6 +6,8 @@ Resources:
     Rule 1: matches /prometheus/api/v1/push + X-Scope-OrgID header → rewrites path
             (strips /prometheus prefix) and forwards to backend.
     Rule 2: matches /prometheus/api/v1/push only (no header) → returns 401 via HTTPRouteFilter.
+    Rule 3: matches /otlp/v1/metrics + X-Scope-OrgID header → forwards to backend (no rewrite).
+    Rule 4: matches /otlp/v1/metrics only (no header) → returns 401 via HTTPRouteFilter.
   - SecurityPolicy: enforces JWT validation using auth.jwt.providers.
   - HTTPRouteFilter (rewrite): strips the /prometheus prefix before forwarding
     (/prometheus/api/v1/push → /api/v1/push).
@@ -13,6 +15,7 @@ Resources:
 
 Exposed paths:
   /prometheus/api/v1/push  (rewritten to /api/v1/push upstream)
+  /otlp/v1/metrics         (forwarded as-is; nginx gateway proxies to Mimir OTLP ingest)
 */}}
 {{- if and .Values.mimir.enabled .Values.auth.jwt.providers -}}
 ---
@@ -70,6 +73,38 @@ spec:
     - path:
         type: PathPrefix
         value: /prometheus/api/v1/push
+  - backendRefs:
+    - name: mimir-gateway
+      namespace: {{ .Values.mimir.namespace }}
+      port: 80
+    matches:
+    - path:
+        type: PathPrefix
+        value: /otlp/v1/metrics
+      headers:
+      - name: X-Scope-OrgID
+        value: "^.+$"
+        type: RegularExpression
+    filters:
+    - type: ResponseHeaderModifier
+      responseHeaderModifier:
+        set:
+        - name: X-Scope-OrgID
+          value: "%REQ(X-Scope-OrgID)%"
+  - backendRefs:
+    - name: mimir-gateway
+      namespace: {{ .Values.mimir.namespace }}
+      port: 80
+    filters:
+    - type: ExtensionRef
+      extensionRef:
+        group: gateway.envoyproxy.io
+        kind: HTTPRouteFilter
+        name: {{ include "resource.default.name" . }}-mimir-write-api-headers-check
+    matches:
+    - path:
+        type: PathPrefix
+        value: /otlp/v1/metrics
 ---
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: SecurityPolicy


### PR DESCRIPTION
## Summary

Adds OTLP ingestion paths to the Mimir and Loki write-API HTTPRoutes so that workload-cluster Alloy events collectors can push OTLP telemetry directly to the platform backends.

**Mimir write-API HTTPRoute** — 2 new rules:
- Rule 3: `POST /otlp/v1/metrics` + `X-Scope-OrgID` header → forwarded to `mimir-gateway:80` (no path rewrite; Mimir nginx already proxies `/otlp` internally)
- Rule 4: `POST /otlp/v1/metrics` without header → 401 (reuses existing `headers-check` HTTPRouteFilter)

**Loki write-API HTTPRoute** — 2 new rules:
- Rule 3: `POST /otlp/v1/logs` + `X-Scope-OrgID` header → forwarded to `loki-gateway:80`
- Rule 4: `POST /otlp/v1/logs` without header → 401 (reuses existing `headers-check` HTTPRouteFilter)

## Context

The `alloy-events` collector is being extended to act as a unified OTLP gateway (see [observability-operator#739](https://github.com/giantswarm/observability-operator/pull/739)). The MC-side Gateway API routes (shared-configs) are handled in [shared-configs#595](https://github.com/giantswarm/shared-configs/pull/595). This PR covers the WC-side routes exposed by observability-platform-api.

## Test plan

- [ ] `helm template` renders valid HTTPRoute YAML with the new rules
- [ ] Deploy to test WC and verify `POST /otlp/v1/metrics` with `X-Scope-OrgID` returns 200 from Mimir
- [ ] Verify `POST /otlp/v1/metrics` without `X-Scope-OrgID` returns 401
- [ ] Deploy to test WC and verify `POST /otlp/v1/logs` with `X-Scope-OrgID` returns 204 from Loki
- [ ] Verify `POST /otlp/v1/logs` without `X-Scope-OrgID` returns 401

🤖 Generated with [Claude Code](https://claude.com/claude-code)