### PR TITLE
Add Basic Auth support to all Gateway API routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add Basic Auth support to all Gateway API routes via `<service>.basicAuth.secretName` (per service: `loki`, `mimir`, `tempo`).
+  Routes now accept either `Authorization: Basic` or `Authorization: Bearer` credentials — configurable independently per service namespace.
+
 ## [0.3.0] - 2026-03-11
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The **observability-platform-api** provides the external access layer for Giant 
 ### What this app is for:
 
 - **External API Access**: Secure HTTP/HTTPS endpoints for external systems to interact with observability services
-- **Authentication Gateway**: OIDC-based authentication and tenant routing for all external requests
+- **Authentication Gateway**: OIDC JWT and/or Basic Auth authentication and tenant routing for all external requests
 - **Multi-Service Routing**: Unified domain with path-based routing to different observability backends
 - **Access Control**: Enforcement of tenant isolation via Envoy Gateway `SecurityPolicy` for all external access
 
@@ -49,6 +49,7 @@ The observability-platform-api creates separate `HTTPRoute` resources under a un
 │             │ /loki/api/v1/rules                                           │                                  │               │
 │             │ /loki/api/v1/detected_labels                                 │                                  │               │
 │ HTTPS       │ /loki/api/v1/push                                            │ Logs / Loki                      │ Write         │
+│ HTTPS       │ /otlp/v1/logs                                                │ Logs / Loki (OTLP)               │ Write         │
 │ HTTPS       │ /prometheus/api/v1/query                                     │ Metrics / Mimir                  │ Read          │
 │             │ /prometheus/api/v1/query_range                               │                                  │               │
 │             │ /prometheus/api/v1/query_exemplars                           │                                  │               │
@@ -59,6 +60,7 @@ The observability-platform-api creates separate `HTTPRoute` resources under a un
 │             │ /prometheus/api/v1/metadata                                  │                                  │               │
 │             │ /prometheus/api/v1/detected_labels                           │                                  │               │
 │ HTTPS       │ /prometheus/api/v1/push  (rewritten → /api/v1/push)         │ Metrics / Mimir                  │ Write         │
+│ HTTPS       │ /otlp/v1/metrics                                             │ Metrics / Mimir (OTLP)           │ Write         │
 │ HTTPS       │ /tempo/api/echo                                              │ Traces / Tempo                   │ Read          │
 │             │ /tempo/api/status/buildinfo                                  │                                  │               │
 │             │ /tempo/api/metrics/query_range                               │                                  │               │
@@ -76,15 +78,13 @@ The observability-platform-api creates separate `HTTPRoute` resources under a un
 
 ### Authentication
 
-All routes (read and write) use Envoy Gateway's native JWT validation via `SecurityPolicy.jwt`. This validates Bearer tokens directly against the JWKS endpoint of each configured issuer, with no external auth service required.
-
-Multiple OIDC providers are supported — tokens from any configured issuer are accepted. This handles both human users (OIDC sessions via Dex, Azure AD, etc.) and applications (Azure AD service principals, any OIDC-compliant IdP).
+All routes (read and write) support two authentication methods via Envoy Gateway `SecurityPolicy` — JWT Bearer tokens and HTTP Basic Auth. They can be configured independently per service, and when both are set, routes accept either credential type (OR logic).
 
 All routes additionally enforce that the `X-Scope-OrgID` header is present and non-empty — requests missing it receive a `401`.
 
 #### Configuring JWT providers
 
-Set `auth.jwt.providers` to the list of trusted OIDC issuers. At least one provider is required when any service is enabled:
+Set `auth.jwt.providers` to the list of trusted OIDC issuers. JWT validation is done inline by Envoy Gateway against the issuer's JWKS endpoint — no external auth service required.
 
 ```yaml
 auth:
@@ -100,7 +100,34 @@ auth:
         uri: "https://login.microsoftonline.com/<tenant-id>/discovery/v2.0/keys"
 ```
 
-Each provider entry maps directly to an Envoy Gateway JWT provider. Tokens are validated against the issuer's JWKS endpoint; any token from a listed issuer is accepted. Helm template strings are supported in all fields.
+Multiple OIDC providers are supported — tokens from any configured issuer are accepted. This handles both human users (OIDC sessions via Dex, Azure AD, etc.) and applications (Azure AD service principals, any OIDC-compliant IdP). Helm template strings are supported in all fields.
+
+#### Configuring Basic Auth
+
+Set `<service>.basicAuth.secretName` to the name of a Kubernetes Secret in `.htpasswd` format, placed in the service's own namespace. Each service is configured independently since they live in different namespaces (`loki`, `mimir`, `tempo`).
+
+```yaml
+loki:
+  basicAuth:
+    secretName: "loki-basic-auth"  # Secret in the loki namespace
+
+mimir:
+  basicAuth:
+    secretName: "mimir-basic-auth"  # Secret in the mimir namespace
+
+tempo:
+  basicAuth:
+    secretName: "tempo-basic-auth"  # Secret in the tempo namespace
+```
+
+The Secret must contain a `users` key with `.htpasswd`-formatted credentials. Example using `htpasswd`:
+
+```bash
+htpasswd -c auth myuser
+kubectl create secret generic loki-basic-auth --from-file=users=auth -n loki
+```
+
+When both JWT and Basic Auth are configured for the same service, routes accept either credential type — callers can use whichever method they support.
 
 ## Architecture Notes
 
@@ -116,7 +143,8 @@ This app creates multiple `HTTPRoute` resources rather than a single route becau
 
 **Operational Considerations:**
 
-- All routes share the same hostname, `X-Scope-OrgID` enforcement, and JWT provider list
+- All routes share the same hostname and `X-Scope-OrgID` enforcement
+- JWT providers (`auth.jwt.providers`) are shared across all services; Basic Auth secrets are per-service
 - JWT validation is done inline by Envoy Gateway — no external auth service required
 
 ## Configuration & Deployment

--- a/TESTING.md
+++ b/TESTING.md
@@ -11,18 +11,18 @@ This document describes how to configure and test all exposed routes (Loki, Mimi
 
 ## 1. Helm template check
 
-Before deploying, verify the rendered output has no stale `extAuth` references and that `jwt.providers` is rendered correctly:
+Before deploying, verify the rendered output has no stale `extAuth` references and that auth blocks are rendered correctly:
 
 ```bash
 helm template observability-platform-api \
   ./helm/observability-platform-api \
   -f helm/observability-platform-api/ci/test-values.yaml
 
-# Confirm jwt: blocks are present, no extAuth: blocks
+# Confirm jwt: and basicAuth: blocks are present in SecurityPolicy, no extAuth: blocks
 helm template observability-platform-api \
   ./helm/observability-platform-api \
   -f helm/observability-platform-api/ci/test-values.yaml \
-  | grep -A8 'kind: SecurityPolicy'
+  | grep -A12 'kind: SecurityPolicy'
 
 helm template observability-platform-api \
   ./helm/observability-platform-api \
@@ -30,22 +30,30 @@ helm template observability-platform-api \
   | grep -c extAuth
 # expect: 0
 
-# Verify that enabling a service with no providers renders nothing (no routes created)
+# Verify that enabling a service with no auth configured renders nothing (no routes created)
 helm template observability-platform-api ./helm/observability-platform-api \
   --set loki.enabled=true | grep -c 'kind:'
 # expect: 0
+
+# Verify basicAuth-only rendering (no JWT providers)
+helm template observability-platform-api ./helm/observability-platform-api \
+  --set loki.enabled=true \
+  --set loki.basicAuth.secretName=loki-basic-auth \
+  | grep -A6 'kind: SecurityPolicy'
+# expect: SecurityPolicy with only basicAuth: block (no jwt: block)
 ```
 
-### What happens when `auth.jwt.providers` is empty?
+### What happens when auth is not configured?
 
-Each route template uses `{{- if and .Values.<service>.enabled .Values.auth.jwt.providers -}}`,
-so resources are only rendered when both the service is enabled and providers are configured.
+Each route template renders only when the service is enabled **and** at least one auth method is configured for that service.
 
-| Services enabled | `auth.jwt.providers` | Result |
-|-----------------|---------------------|--------|
-| All false (default) | `[]` | Chart renders fine (no routes created) |
-| Any true | `[]` | Chart renders fine (no routes created) |
-| Any true | populated | Chart renders correctly |
+| Services enabled | `auth.jwt.providers` | `<svc>.basicAuth.secretName` | Result |
+|-----------------|---------------------|-------------------------------------|--------|
+| All false (default) | `[]` | `""` | Chart renders fine (no routes created) |
+| Any true | `[]` | `""` | Chart renders fine (no routes created) |
+| Any true | populated | `""` | Routes rendered with JWT only |
+| Any true | `[]` | set | Routes rendered with Basic Auth only |
+| Any true | populated | set | Routes rendered with both JWT and Basic Auth |
 
 ## 2. Get a test token
 
@@ -92,17 +100,23 @@ BASE="https://observability.<codename>.<base-domain>"
 ORG="my-tenant"
 AUTH="Authorization: Bearer $TOKEN"
 SCOPE="X-Scope-OrgID: $ORG"
+
+# For Basic Auth testing (replace with actual credentials from the .htpasswd secret)
+BASIC_USER="myuser"
+BASIC_PASS="mypassword"
+BASIC_AUTH="Authorization: Basic $(echo -n "$BASIC_USER:$BASIC_PASS" | base64)"
 ```
 
 ## 4. Test all paths
 
-For every path, three scenarios are validated:
+For every path, the following scenarios are validated:
 
 | Scenario | Expected (HTTP) | Expected (gRPC) |
 |----------|----------------|-----------------|
 | Valid JWT + `X-Scope-OrgID` present | 2xx (backend response) | grpc-status: 12 (backend reached) |
+| Valid Basic Auth + `X-Scope-OrgID` present | 2xx (backend response) | grpc-status: 12 (backend reached) |
 | Valid JWT, `X-Scope-OrgID` missing | 401 | no-route rejection (not a strict 401) |
-| No JWT | 401 | grpc-status: 16 (UNAUTHENTICATED) |
+| No auth credential | 401 | grpc-status: 16 (UNAUTHENTICATED) |
 
 ### Loki read
 
@@ -110,9 +124,10 @@ Backend: `loki-gateway:80`. No path rewrite.
 
 ```bash
 # Full auth scenario test on representative path
-curl -si "$BASE/loki/api/v1/labels" -H "$AUTH" -H "$SCOPE"  # expect 2xx
-curl -si "$BASE/loki/api/v1/labels" -H "$AUTH"               # expect 401
-curl -si "$BASE/loki/api/v1/labels" -H "$SCOPE"              # expect 401
+curl -si "$BASE/loki/api/v1/labels" -H "$AUTH" -H "$SCOPE"        # expect 2xx (JWT)
+curl -si "$BASE/loki/api/v1/labels" -H "$BASIC_AUTH" -H "$SCOPE"  # expect 2xx (Basic Auth)
+curl -si "$BASE/loki/api/v1/labels" -H "$AUTH"                     # expect 401
+curl -si "$BASE/loki/api/v1/labels" -H "$SCOPE"                    # expect 401
 
 # Smoke test all paths (valid auth)
 for p in \
@@ -139,7 +154,11 @@ PAYLOAD='{"streams":[{"stream":{"job":"test"},"values":[["'"$(date +%s%N)"'","te
 
 curl -si -X POST "$BASE/loki/api/v1/push" \
   -H "$AUTH" -H "$SCOPE" -H "Content-Type: application/json" -d "$PAYLOAD"
-# expect: 204
+# expect: 204 (JWT)
+
+curl -si -X POST "$BASE/loki/api/v1/push" \
+  -H "$BASIC_AUTH" -H "$SCOPE" -H "Content-Type: application/json" -d "$PAYLOAD"
+# expect: 204 (Basic Auth)
 
 curl -si -X POST "$BASE/loki/api/v1/push" \
   -H "$AUTH" -H "Content-Type: application/json" -d "$PAYLOAD"
@@ -147,7 +166,7 @@ curl -si -X POST "$BASE/loki/api/v1/push" \
 
 curl -si -X POST "$BASE/loki/api/v1/push" \
   -H "$SCOPE" -H "Content-Type: application/json" -d "$PAYLOAD"
-# expect: 401 (missing JWT)
+# expect: 401 (no auth credential)
 ```
 
 ### Mimir read
@@ -155,9 +174,10 @@ curl -si -X POST "$BASE/loki/api/v1/push" \
 Backend: `mimir-gateway:80`. No path rewrite.
 
 ```bash
-curl -si "$BASE/prometheus/api/v1/labels" -H "$AUTH" -H "$SCOPE"  # expect 2xx
-curl -si "$BASE/prometheus/api/v1/labels" -H "$AUTH"               # expect 401
-curl -si "$BASE/prometheus/api/v1/labels" -H "$SCOPE"              # expect 401
+curl -si "$BASE/prometheus/api/v1/labels" -H "$AUTH" -H "$SCOPE"        # expect 2xx (JWT)
+curl -si "$BASE/prometheus/api/v1/labels" -H "$BASIC_AUTH" -H "$SCOPE"  # expect 2xx (Basic Auth)
+curl -si "$BASE/prometheus/api/v1/labels" -H "$AUTH"                     # expect 401
+curl -si "$BASE/prometheus/api/v1/labels" -H "$SCOPE"                    # expect 401
 
 for p in \
   /prometheus/api/v1/label/__name__/values \
@@ -193,9 +213,10 @@ curl -si -X POST "$BASE/prometheus/api/v1/push" -H "$SCOPE"  # expect 401
 Backend: `tempo-query-frontend:3200`. Path rewrite: `/tempo` prefix stripped before forwarding.
 
 ```bash
-curl -si "$BASE/tempo/api/echo" -H "$AUTH" -H "$SCOPE"  # expect 200, body: "echo"
-curl -si "$BASE/tempo/api/echo" -H "$AUTH"               # expect 401
-curl -si "$BASE/tempo/api/echo" -H "$SCOPE"              # expect 401
+curl -si "$BASE/tempo/api/echo" -H "$AUTH" -H "$SCOPE"        # expect 200, body: "echo" (JWT)
+curl -si "$BASE/tempo/api/echo" -H "$BASIC_AUTH" -H "$SCOPE"  # expect 200, body: "echo" (Basic Auth)
+curl -si "$BASE/tempo/api/echo" -H "$AUTH"                     # expect 401
+curl -si "$BASE/tempo/api/echo" -H "$SCOPE"                    # expect 401
 
 for p in \
   /tempo/api/status/buildinfo \

--- a/helm/observability-platform-api/ci/test-values.yaml
+++ b/helm/observability-platform-api/ci/test-values.yaml
@@ -13,6 +13,8 @@ loki:
   parentRefs:
   - name: giantswarm-default
     namespace: envoy-gateway-system
+  basicAuth:
+    secretName: "loki-basic-auth"
 
 mimir:
   enabled: true
@@ -21,6 +23,8 @@ mimir:
   parentRefs:
   - name: giantswarm-default
     namespace: envoy-gateway-system
+  basicAuth:
+    secretName: "mimir-basic-auth"
 
 tempo:
   enabled: true
@@ -29,3 +33,5 @@ tempo:
   parentRefs:
   - name: giantswarm-default
     namespace: envoy-gateway-system
+  basicAuth:
+    secretName: "tempo-basic-auth"

--- a/helm/observability-platform-api/templates/route-loki-read.yaml
+++ b/helm/observability-platform-api/templates/route-loki-read.yaml
@@ -5,7 +5,7 @@ Resources:
   - HTTPRoute: routes read requests to loki-gateway:80 in loki.namespace.
     Rule 1: matches path + X-Scope-OrgID header (regex ^.+$) → forwards to backend.
     Rule 2: matches path only (no header) → returns 401 via HTTPRouteFilter.
-  - SecurityPolicy: enforces JWT validation using auth.jwt.providers.
+  - SecurityPolicy: enforces JWT and/or Basic Auth via auth.jwt.providers and loki.basicAuth.secretName.
   - HTTPRouteFilter: returns 401 when X-Scope-OrgID header is missing.
 
 Exposed paths:
@@ -13,7 +13,7 @@ Exposed paths:
   /loki/api/v1/query, /loki/api/v1/query_range, /loki/api/v1/index,
   /loki/api/v1/series, /loki/api/v1/detected_labels
 */}}
-{{- if and .Values.loki.enabled .Values.auth.jwt.providers -}}
+{{- if and .Values.loki.enabled (or .Values.auth.jwt.providers .Values.loki.basicAuth.secretName) -}}
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
@@ -147,9 +147,16 @@ spec:
   - group: gateway.networking.k8s.io
     kind: HTTPRoute
     name: {{ include "resource.default.name" . }}-loki-read-api
+  {{- if .Values.auth.jwt.providers }}
   jwt:
     providers:
       {{- toYaml .Values.auth.jwt.providers | nindent 6 }}
+  {{- end }}
+  {{- if .Values.loki.basicAuth.secretName }}
+  basicAuth:
+    users:
+      name: {{ .Values.loki.basicAuth.secretName }}
+  {{- end }}
 ---
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: HTTPRouteFilter

--- a/helm/observability-platform-api/templates/route-loki-write.yaml
+++ b/helm/observability-platform-api/templates/route-loki-write.yaml
@@ -7,14 +7,14 @@ Resources:
     Rule 2: matches /loki/api/v1/push only (no header) → returns 401 via HTTPRouteFilter.
     Rule 3: matches /otlp/v1/logs + X-Scope-OrgID header → forwards to backend (no rewrite).
     Rule 4: matches /otlp/v1/logs only (no header) → returns 401 via HTTPRouteFilter.
-  - SecurityPolicy: enforces JWT validation using auth.jwt.providers.
+  - SecurityPolicy: enforces JWT and/or Basic Auth via auth.jwt.providers and loki.basicAuth.secretName.
   - HTTPRouteFilter: returns 401 when X-Scope-OrgID header is missing.
 
 Exposed paths:
   /loki/api/v1/push
   /otlp/v1/logs    (forwarded as-is; nginx gateway proxies to Loki OTLP ingest)
 */}}
-{{- if and .Values.loki.enabled .Values.auth.jwt.providers -}}
+{{- if and .Values.loki.enabled (or .Values.auth.jwt.providers .Values.loki.basicAuth.secretName) -}}
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
@@ -110,9 +110,16 @@ spec:
   - group: gateway.networking.k8s.io
     kind: HTTPRoute
     name: {{ include "resource.default.name" . }}-loki-write-api
+  {{- if .Values.auth.jwt.providers }}
   jwt:
     providers:
       {{- toYaml .Values.auth.jwt.providers | nindent 6 }}
+  {{- end }}
+  {{- if .Values.loki.basicAuth.secretName }}
+  basicAuth:
+    users:
+      name: {{ .Values.loki.basicAuth.secretName }}
+  {{- end }}
 ---
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: HTTPRouteFilter

--- a/helm/observability-platform-api/templates/route-mimir-read.yaml
+++ b/helm/observability-platform-api/templates/route-mimir-read.yaml
@@ -5,7 +5,7 @@ Resources:
   - HTTPRoute: routes read requests to mimir-gateway:80 in mimir.namespace.
     Rule 1: matches path + X-Scope-OrgID header (regex ^.+$) → forwards to backend.
     Rule 2: matches path only (no header) → returns 401 via HTTPRouteFilter.
-  - SecurityPolicy: enforces JWT validation using auth.jwt.providers.
+  - SecurityPolicy: enforces JWT and/or Basic Auth via auth.jwt.providers and mimir.basicAuth.secretName.
   - HTTPRouteFilter: returns 401 when X-Scope-OrgID header is missing.
 
 Exposed paths (Prometheus-compatible API):
@@ -14,7 +14,7 @@ Exposed paths (Prometheus-compatible API):
   /prometheus/api/v1/query_exemplars, /prometheus/api/v1/status,
   /prometheus/api/v1/metadata, /prometheus/api/v1/detected_labels
 */}}
-{{- if and .Values.mimir.enabled .Values.auth.jwt.providers -}}
+{{- if and .Values.mimir.enabled (or .Values.auth.jwt.providers .Values.mimir.basicAuth.secretName) -}}
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
@@ -158,9 +158,16 @@ spec:
   - group: gateway.networking.k8s.io
     kind: HTTPRoute
     name: {{ include "resource.default.name" . }}-mimir-read-api
+  {{- if .Values.auth.jwt.providers }}
   jwt:
     providers:
       {{- toYaml .Values.auth.jwt.providers | nindent 6 }}
+  {{- end }}
+  {{- if .Values.mimir.basicAuth.secretName }}
+  basicAuth:
+    users:
+      name: {{ .Values.mimir.basicAuth.secretName }}
+  {{- end }}
 ---
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: HTTPRouteFilter

--- a/helm/observability-platform-api/templates/route-mimir-write.yaml
+++ b/helm/observability-platform-api/templates/route-mimir-write.yaml
@@ -8,7 +8,7 @@ Resources:
     Rule 2: matches /prometheus/api/v1/push only (no header) → returns 401 via HTTPRouteFilter.
     Rule 3: matches /otlp/v1/metrics + X-Scope-OrgID header → forwards to backend (no rewrite).
     Rule 4: matches /otlp/v1/metrics only (no header) → returns 401 via HTTPRouteFilter.
-  - SecurityPolicy: enforces JWT validation using auth.jwt.providers.
+  - SecurityPolicy: enforces JWT and/or Basic Auth via auth.jwt.providers and mimir.basicAuth.secretName.
   - HTTPRouteFilter (rewrite): strips the /prometheus prefix before forwarding
     (/prometheus/api/v1/push → /api/v1/push).
   - HTTPRouteFilter (headers-check): returns 401 when X-Scope-OrgID header is missing.
@@ -17,7 +17,7 @@ Exposed paths:
   /prometheus/api/v1/push  (rewritten to /api/v1/push upstream)
   /otlp/v1/metrics         (forwarded as-is; nginx gateway proxies to Mimir OTLP ingest)
 */}}
-{{- if and .Values.mimir.enabled .Values.auth.jwt.providers -}}
+{{- if and .Values.mimir.enabled (or .Values.auth.jwt.providers .Values.mimir.basicAuth.secretName) -}}
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
@@ -118,9 +118,16 @@ spec:
   - group: gateway.networking.k8s.io
     kind: HTTPRoute
     name: {{ include "resource.default.name" . }}-mimir-write-api
+  {{- if .Values.auth.jwt.providers }}
   jwt:
     providers:
       {{- toYaml .Values.auth.jwt.providers | nindent 6 }}
+  {{- end }}
+  {{- if .Values.mimir.basicAuth.secretName }}
+  basicAuth:
+    users:
+      name: {{ .Values.mimir.basicAuth.secretName }}
+  {{- end }}
 ---
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: HTTPRouteFilter

--- a/helm/observability-platform-api/templates/route-tempo-read.yaml
+++ b/helm/observability-platform-api/templates/route-tempo-read.yaml
@@ -5,7 +5,7 @@ Resources (HTTP):
   - HTTPRoute (tempo-read-api): routes read requests to tempo-query-frontend:3200.
     Rule 1: matches path + X-Scope-OrgID header → strips /tempo prefix and forwards.
     Rule 2: matches path only (no header) → returns 401 via HTTPRouteFilter.
-  - SecurityPolicy: enforces JWT validation using auth.jwt.providers.
+  - SecurityPolicy: enforces JWT and/or Basic Auth via auth.jwt.providers and tempo.basicAuth.secretName.
   - HTTPRouteFilter (rewrite): strips the /tempo prefix before forwarding
     (/tempo/api/... → /api/...).
   - HTTPRouteFilter (headers-check): returns 401 when X-Scope-OrgID header is missing.
@@ -20,12 +20,12 @@ Resources (gRPC):
     Requests missing X-Scope-OrgID do not match and are rejected by Envoy (no route match).
     Note: GRPCRoute does not support HTTPRouteFilter ExtensionRef, so a directResponse
     rule cannot be used; missing-header requests get a non-401 rejection instead.
-  - SecurityPolicy: enforces JWT validation using auth.jwt.providers.
+  - SecurityPolicy: enforces JWT and/or Basic Auth via auth.jwt.providers and tempo.basicAuth.secretName.
 
 Exposed gRPC path:
   any service matching regex "tempopb\.[^/]+"  (e.g. tempopb.StreamingQuerier, tempopb.Querier)
 */}}
-{{- if and .Values.tempo.enabled .Values.auth.jwt.providers -}}
+{{- if and .Values.tempo.enabled (or .Values.auth.jwt.providers .Values.tempo.basicAuth.secretName) -}}
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
@@ -154,9 +154,16 @@ spec:
   - group: gateway.networking.k8s.io
     kind: HTTPRoute
     name: {{ include "resource.default.name" . }}-tempo-read-api
+  {{- if .Values.auth.jwt.providers }}
   jwt:
     providers:
       {{- toYaml .Values.auth.jwt.providers | nindent 6 }}
+  {{- end }}
+  {{- if .Values.tempo.basicAuth.secretName }}
+  basicAuth:
+    users:
+      name: {{ .Values.tempo.basicAuth.secretName }}
+  {{- end }}
 ---
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: HTTPRouteFilter
@@ -236,7 +243,14 @@ spec:
   - group: gateway.networking.k8s.io
     kind: GRPCRoute
     name: {{ include "resource.default.name" . }}-tempo-read-api-grpc
+  {{- if .Values.auth.jwt.providers }}
   jwt:
     providers:
       {{- toYaml .Values.auth.jwt.providers | nindent 6 }}
+  {{- end }}
+  {{- if .Values.tempo.basicAuth.secretName }}
+  basicAuth:
+    users:
+      name: {{ .Values.tempo.basicAuth.secretName }}
+  {{- end }}
 {{- end }}

--- a/helm/observability-platform-api/templates/route-tempo-write.yaml
+++ b/helm/observability-platform-api/templates/route-tempo-write.yaml
@@ -5,13 +5,13 @@ Resources:
   - HTTPRoute: routes OTLP trace ingestion to tempo-distributor:4318 in tempo.namespace.
     Rule 1: matches /v1/traces + X-Scope-OrgID header → forwards to backend.
     Rule 2: matches /v1/traces only (no header) → returns 401 via HTTPRouteFilter.
-  - SecurityPolicy: enforces JWT validation using auth.jwt.providers.
+  - SecurityPolicy: enforces JWT and/or Basic Auth via auth.jwt.providers and tempo.basicAuth.secretName.
   - HTTPRouteFilter: returns 401 when X-Scope-OrgID header is missing.
 
 Exposed paths:
   /v1/traces  (OTLP HTTP trace ingestion)
 */}}
-{{- if and .Values.tempo.enabled .Values.auth.jwt.providers -}}
+{{- if and .Values.tempo.enabled (or .Values.auth.jwt.providers .Values.tempo.basicAuth.secretName) -}}
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
@@ -75,9 +75,16 @@ spec:
   - group: gateway.networking.k8s.io
     kind: HTTPRoute
     name: {{ include "resource.default.name" . }}-tempo-otlp-write-api
+  {{- if .Values.auth.jwt.providers }}
   jwt:
     providers:
       {{- toYaml .Values.auth.jwt.providers | nindent 6 }}
+  {{- end }}
+  {{- if .Values.tempo.basicAuth.secretName }}
+  basicAuth:
+    users:
+      name: {{ .Values.tempo.basicAuth.secretName }}
+  {{- end }}
 ---
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: HTTPRouteFilter

--- a/helm/observability-platform-api/values.schema.json
+++ b/helm/observability-platform-api/values.schema.json
@@ -16,6 +16,16 @@
                 },
                 "parentRefs": {
                     "type": "array"
+                },
+                "basicAuth": {
+                    "type": "object",
+                    "description": "Basic Auth config for Loki routes. When set alongside JWT, routes accept either credential type.",
+                    "properties": {
+                        "secretName": {
+                            "type": "string",
+                            "description": "Name of the .htpasswd Secret in the loki namespace."
+                        }
+                    }
                 }
             }
         },
@@ -33,6 +43,16 @@
                 },
                 "parentRefs": {
                     "type": "array"
+                },
+                "basicAuth": {
+                    "type": "object",
+                    "description": "Basic Auth config for Mimir routes. When set alongside JWT, routes accept either credential type.",
+                    "properties": {
+                        "secretName": {
+                            "type": "string",
+                            "description": "Name of the .htpasswd Secret in the mimir namespace."
+                        }
+                    }
                 }
             }
         },
@@ -50,6 +70,16 @@
                 },
                 "parentRefs": {
                     "type": "array"
+                },
+                "basicAuth": {
+                    "type": "object",
+                    "description": "Basic Auth config for Tempo routes. When set alongside JWT, routes accept either credential type.",
+                    "properties": {
+                        "secretName": {
+                            "type": "string",
+                            "description": "Name of the .htpasswd Secret in the tempo namespace."
+                        }
+                    }
                 }
             }
         },

--- a/helm/observability-platform-api/values.yaml
+++ b/helm/observability-platform-api/values.yaml
@@ -27,6 +27,10 @@ loki:
   parentRefs:
   - name: giantswarm-default
     namespace: envoy-gateway-system
+  basicAuth:
+    # -- Name of a Kubernetes Secret with .htpasswd-formatted credentials in the loki namespace.
+    # When set alongside auth.jwt.providers, routes accept either Basic Auth or JWT.
+    secretName: ""
 
 mimir:
   enabled: false
@@ -36,6 +40,10 @@ mimir:
   parentRefs:
   - name: giantswarm-default
     namespace: envoy-gateway-system
+  basicAuth:
+    # -- Name of a Kubernetes Secret with .htpasswd-formatted credentials in the mimir namespace.
+    # When set alongside auth.jwt.providers, routes accept either Basic Auth or JWT.
+    secretName: ""
 
 tempo:
   enabled: false
@@ -45,6 +53,10 @@ tempo:
   parentRefs:
   - name: giantswarm-default
     namespace: envoy-gateway-system
+  basicAuth:
+    # -- Name of a Kubernetes Secret with .htpasswd-formatted credentials in the tempo namespace.
+    # When set alongside auth.jwt.providers, routes accept either Basic Auth or JWT.
+    secretName: ""
 
 ingresses:
   - name: loki


### PR DESCRIPTION
With this PR, the goal is to replace the routes we currently define per app and so we also dogfood the same api customers can use

## Summary

- Add `basicAuth.secretName` per service (`loki`, `mimir`, `tempo`) — a Kubernetes Secret name in `.htpasswd` format placed in the service's own namespace
- Update all 6 route templates: rendering condition now uses `(or jwt.providers basicAuth.secretName)`, and `SecurityPolicy` conditionally includes `jwt` and/or `basicAuth` blocks
- Routes accept either `Authorization: Basic` or `Authorization: Bearer` (OR logic — whichever the caller provides)
- Update `CHANGELOG.md`, `README.md` (new Configuring Basic Auth section + missing OTLP routes in table), and `TESTING.md` (new test variables, scenarios, and helm check commands)