### PR TITLE
Add Loki gRPC OTLP write route and consistent read/write values API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Restructure per-service path configuration under nested `read` and `write` objects (e.g. `loki.readPaths` → `loki.read.paths`, `mimir.writePassthroughPaths` → `mimir.write.paths`).
+- Rename `mimir.writeRewritePaths` → `mimir.write.stripPrefixPaths` to clarify that the `/prometheus` prefix is stripped before forwarding; add equivalent `stripPrefixPaths: []` defaults to loki and tempo write config.
+- Move `loki.otlpGrpc` → `loki.write.grpc` for consistency with `tempo.read.grpc`.
+- Expose Tempo gRPC backend config in values (`tempo.read.grpc.backendService`, `tempo.read.grpc.backendPort`) instead of hardcoding in the template.
 - Restructure Helm templates into per-service subdirectories (`templates/loki/`, `templates/mimir/`, `templates/tempo/`).
 - Consolidate per-route `SecurityPolicy` resources: Loki and Mimir now use a single `SecurityPolicy` per service (covering both read and write routes). Tempo retains separate policies due to the distinct GRPCRoute.
 - Share `HTTPRouteFilter` resources within each service: a single `headers-check` filter and (for Mimir/Tempo) a single `rewrite` filter are now referenced by all routes in that service namespace.

--- a/README.md
+++ b/README.md
@@ -73,7 +73,8 @@ The observability-platform-api creates `HTTPRoute` and `GRPCRoute` resources und
 │             │ ├── /tempopb.StreamingQuerier.SearchTagsV2                   │                                  │               │
 │             │ ├── /tempopb.StreamingQuerier.MetricsQueryRange              │                                  │               │
 │             │ └── ...                                                      │                                  │               │
-│ HTTPS       │ /v1/traces                                                   │ OpenTelemetry Traces / Tempo     │ Write         │
+│ HTTPS       │ /v1/traces                                                   │ Traces / Tempo (OTLP HTTP)       │ Write         │
+│ gRPC (+TLS) │ opentelemetry.proto.collector.trace.v1.TraceService          │ Traces / Tempo (OTLP gRPC)       │ Write         │
 └─────────────┴──────────────────────────────────────────────────────────────┴──────────────────────────────────┴───────────────┘
 ```
 
@@ -145,8 +146,8 @@ This app creates multiple `HTTPRoute` and `GRPCRoute` resources (one per service
 **Template structure** — templates are organised per service under `templates/loki/`, `templates/mimir/`, and `templates/tempo/`. Each directory contains:
 - `route-read.yaml` — HTTP read `HTTPRoute`
 - `route-write.yaml` — HTTP write `HTTPRoute`
-- `route-grpc.yaml` — gRPC `GRPCRoute` (Loki write OTLP / Tempo read)
-- `securitypolicy.yaml` — one `SecurityPolicy` per service (covers all routes in that namespace)
+- `route-grpc.yaml` — gRPC `GRPCRoute`(s): Loki OTLP write; Tempo read + OTLP write
+- `securitypolicy.yaml` — one `SecurityPolicy` per route for Loki and Mimir (single SP covers all HTTP routes); Tempo requires one SP per route because each `GRPCRoute` must have its own `SecurityPolicy`
 - `filters.yaml` — shared `HTTPRouteFilter` resources (headers-check and path rewrite where applicable)
 
 **Operational Considerations:**

--- a/README.md
+++ b/README.md
@@ -48,6 +48,13 @@ The observability-platform-api creates `HTTPRoute` and `GRPCRoute` resources und
 │             │ /loki/api/v1/index                                           │                                  │               │
 │             │ /loki/api/v1/rules                                           │                                  │               │
 │             │ /loki/api/v1/detected_labels                                 │                                  │               │
+│             │ /loki/api/v1/tail                                            │                                  │               │
+│             │ /loki/api/v1/format_query                                    │                                  │               │
+│             │ /loki/api/v1/index/stats                                     │                                  │               │
+│             │ /loki/api/v1/index/volume                                    │                                  │               │
+│             │ /loki/api/v1/index/volume_range                              │                                  │               │
+│             │ /loki/api/v1/detected_fields                                 │                                  │               │
+│             │ /loki/api/v1/patterns                                        │                                  │               │
 │ HTTPS       │ /loki/api/v1/push                                            │ Logs / Loki                      │ Write         │
 │ HTTPS       │ /otlp/v1/logs                                                │ Logs / Loki (OTLP HTTP)          │ Write         │
 │ gRPC (+TLS) │ opentelemetry.proto.collector.logs.v1.LogsService            │ Logs / Loki (OTLP gRPC)          │ Write         │
@@ -56,6 +63,7 @@ The observability-platform-api creates `HTTPRoute` and `GRPCRoute` resources und
 │             │ /prometheus/api/v1/query_exemplars                           │                                  │               │
 │             │ /prometheus/api/v1/labels                                    │                                  │               │
 │             │ /prometheus/api/v1/label                                     │                                  │               │
+│             │ /prometheus/api/v1/series                                    │                                  │               │
 │             │ /prometheus/api/v1/rules                                     │                                  │               │
 │             │ /prometheus/api/v1/status                                    │                                  │               │
 │             │ /prometheus/api/v1/metadata                                  │                                  │               │
@@ -66,7 +74,10 @@ The observability-platform-api creates `HTTPRoute` and `GRPCRoute` resources und
 │             │ /tempo/api/status/buildinfo                                  │                                  │               │
 │             │ /tempo/api/metrics/query_range                               │                                  │               │
 │             │ /tempo/api/search                                            │                                  │               │
+│             │ /tempo/api/search/tags                                       │                                  │               │
 │             │ /tempo/api/v2/search                                         │                                  │               │
+│             │ /tempo/api/v2/search/tags                                    │                                  │               │
+│             │ /tempo/api/v2/search/tag/{tag}/values                        │                                  │               │
 │             │ /tempo/api/traces                                            │                                  │               │
 │             │ /tempo/api/v2/traces  (all rewritten, /tempo prefix removed) │                                  │               │
 │ gRPC (+TLS) │ /tempopb                                                     │ Traces / Tempo                   │ Read          │

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ This repository contains the Helm chart and configuration templates for creating
 
 ### Route Management
 
-The observability-platform-api creates separate `HTTPRoute` resources under a unified domain for direct access to observability backends. Each route is secured by an Envoy Gateway `SecurityPolicy` (JWT validation) and enforces the `X-Scope-OrgID` tenant header.
+The observability-platform-api creates `HTTPRoute` and `GRPCRoute` resources under a unified domain for direct access to observability backends. Each route is secured by an Envoy Gateway `SecurityPolicy` (JWT and/or Basic Auth) and enforces the `X-Scope-OrgID` tenant header.
 
 ```
 ┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
@@ -49,7 +49,8 @@ The observability-platform-api creates separate `HTTPRoute` resources under a un
 │             │ /loki/api/v1/rules                                           │                                  │               │
 │             │ /loki/api/v1/detected_labels                                 │                                  │               │
 │ HTTPS       │ /loki/api/v1/push                                            │ Logs / Loki                      │ Write         │
-│ HTTPS       │ /otlp/v1/logs                                                │ Logs / Loki (OTLP)               │ Write         │
+│ HTTPS       │ /otlp/v1/logs                                                │ Logs / Loki (OTLP HTTP)          │ Write         │
+│ gRPC (+TLS) │ opentelemetry.proto.collector.logs.v1.LogsService            │ Logs / Loki (OTLP gRPC)          │ Write         │
 │ HTTPS       │ /prometheus/api/v1/query                                     │ Metrics / Mimir                  │ Read          │
 │             │ /prometheus/api/v1/query_range                               │                                  │               │
 │             │ /prometheus/api/v1/query_exemplars                           │                                  │               │
@@ -133,7 +134,7 @@ When both JWT and Basic Auth are configured for the same service, routes accept 
 
 ### Multi-Route Design
 
-This app creates multiple `HTTPRoute` resources rather than a single route because:
+This app creates multiple `HTTPRoute` and `GRPCRoute` resources (one per service per direction) rather than a single route because:
 
 **Benefits:**
 - **Granular Control**: Each service can have independent configuration and lifecycle
@@ -141,11 +142,19 @@ This app creates multiple `HTTPRoute` resources rather than a single route becau
 - **Feature Flags**: Individual routes can be enabled/disabled based on cluster capabilities
 - **Security Boundaries**: Each service can be independently enabled or disabled without affecting others
 
+**Template structure** — templates are organised per service under `templates/loki/`, `templates/mimir/`, and `templates/tempo/`. Each directory contains:
+- `route-read.yaml` — HTTP read `HTTPRoute`
+- `route-write.yaml` — HTTP write `HTTPRoute`
+- `route-grpc.yaml` — gRPC `GRPCRoute` (Loki write OTLP / Tempo read)
+- `securitypolicy.yaml` — one `SecurityPolicy` per service (covers all routes in that namespace)
+- `filters.yaml` — shared `HTTPRouteFilter` resources (headers-check and path rewrite where applicable)
+
 **Operational Considerations:**
 
 - All routes share the same hostname and `X-Scope-OrgID` enforcement
 - JWT providers (`auth.jwt.providers`) are shared across all services; Basic Auth secrets are per-service
 - JWT validation is done inline by Envoy Gateway — no external auth service required
+- gRPC routes (`GRPCRoute`) do not support `HTTPRouteFilter` via `ExtensionRef`, so missing `X-Scope-OrgID` on gRPC requests results in a no-route rejection rather than a strict 401
 
 ## Configuration & Deployment
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -95,28 +95,25 @@ TOKEN=$(kubectl oidc-login get-token \
 
 ## 2b. Get Basic Auth credentials
 
-The BasicAuth credentials are stored in per-service Kubernetes Secrets in htpasswd format. The secret names follow the pattern `<service>-gateway-httproute-auth` in each service namespace.
-
-List available usernames in the secret (passwords are one-way SHA-hashed — you need to know the original password):
+The source secrets are stored in the `org-giantswarm` namespace, named `<mc-name>-observability-<logs|metrics|traces>-auth`. The username is the MC name (e.g. `graveler`). The plain-text password is under the `password` key:
 
 ```bash
-# Example for loki (same pattern for mimir and tempo)
-kubectl get secret loki-gateway-httproute-auth -n loki \
-  -o jsonpath='{.data.\.htpasswd}' | base64 -d | cut -d: -f1
+MC="<mc-name>"  # e.g. graveler
+
+# Loki password:
+kubectl get secret -n org-giantswarm ${MC}-observability-logs-auth -oyaml \
+  | yq .data.password | base64 -d
+
+# Mimir password:
+kubectl get secret -n org-giantswarm ${MC}-observability-metrics-auth -oyaml \
+  | yq .data.password | base64 -d
+
+# Tempo password:
+kubectl get secret -n org-giantswarm ${MC}-observability-traces-auth -oyaml \
+  | yq .data.password | base64 -d
 ```
 
-If you need to create a new test user with a known password:
-
-```bash
-# Add a test user to an existing secret
-EXISTING=$(kubectl get secret loki-gateway-httproute-auth -n loki \
-  -o jsonpath='{.data.\.htpasswd}' | base64 -d)
-NEW_ENTRY=$(htpasswd -nb testuser testpassword)
-kubectl create secret generic loki-gateway-httproute-auth \
-  --from-literal=".htpasswd=${EXISTING}
-${NEW_ENTRY}" \
-  -n loki --dry-run=client -o yaml | kubectl apply -f -
-```
+These source secrets are synced into the service namespaces as `loki-gateway-httproute-auth` (in `loki`), `mimir-gateway-httproute-auth` (in `mimir`), and `tempo-gateway-httproute-auth` (in `tempo`), which is what the `SecurityPolicy` references via `basicAuth.secretName`.
 
 ## 3. Set test variables
 
@@ -127,9 +124,9 @@ AUTH="Authorization: Bearer $TOKEN"
 SCOPE="X-Scope-OrgID: $ORG"
 GRPC_HOST="${BASE#https://}"
 
-# For Basic Auth testing — use credentials from the secret (see section 2b above)
-BASIC_USER="<username from secret>"
-BASIC_PASS="<password — look up in vault or create a test user>"
+# For Basic Auth testing — username is the MC name, password from section 2b above
+BASIC_USER="<mc-name>"  # e.g. graveler
+BASIC_PASS="<password from org-giantswarm secret>"
 BASIC_AUTH="Authorization: Basic $(echo -n "$BASIC_USER:$BASIC_PASS" | base64)"
 ```
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -93,6 +93,31 @@ TOKEN=$(kubectl oidc-login get-token \
   --oidc-client-id=<client-id> | jq -r '.status.token')
 ```
 
+## 2b. Get Basic Auth credentials
+
+The BasicAuth credentials are stored in per-service Kubernetes Secrets in htpasswd format. The secret names follow the pattern `<service>-gateway-httproute-auth` in each service namespace.
+
+List available usernames in the secret (passwords are one-way SHA-hashed — you need to know the original password):
+
+```bash
+# Example for loki (same pattern for mimir and tempo)
+kubectl get secret loki-gateway-httproute-auth -n loki \
+  -o jsonpath='{.data.\.htpasswd}' | base64 -d | cut -d: -f1
+```
+
+If you need to create a new test user with a known password:
+
+```bash
+# Add a test user to an existing secret
+EXISTING=$(kubectl get secret loki-gateway-httproute-auth -n loki \
+  -o jsonpath='{.data.\.htpasswd}' | base64 -d)
+NEW_ENTRY=$(htpasswd -nb testuser testpassword)
+kubectl create secret generic loki-gateway-httproute-auth \
+  --from-literal=".htpasswd=${EXISTING}
+${NEW_ENTRY}" \
+  -n loki --dry-run=client -o yaml | kubectl apply -f -
+```
+
 ## 3. Set test variables
 
 ```bash
@@ -100,10 +125,11 @@ BASE="https://observability.<codename>.<base-domain>"
 ORG="my-tenant"
 AUTH="Authorization: Bearer $TOKEN"
 SCOPE="X-Scope-OrgID: $ORG"
+GRPC_HOST="${BASE#https://}"
 
-# For Basic Auth testing (replace with actual credentials from the .htpasswd secret)
-BASIC_USER="myuser"
-BASIC_PASS="mypassword"
+# For Basic Auth testing — use credentials from the secret (see section 2b above)
+BASIC_USER="<username from secret>"
+BASIC_PASS="<password — look up in vault or create a test user>"
 BASIC_AUTH="Authorization: Basic $(echo -n "$BASIC_USER:$BASIC_PASS" | base64)"
 ```
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -6,7 +6,7 @@ This document describes how to configure and test all exposed routes (Loki, Mimi
 
 - Access to a management cluster with the app deployed
 - `curl` and `jq` installed
-- `grpcurl` installed (for Tempo gRPC testing)
+- `grpcurl` installed (for Tempo and Loki gRPC testing)
 - An Azure AD app registration with a client secret, or a Dex OIDC client
 
 ## 1. Helm template check
@@ -230,9 +230,32 @@ done
 # expect: 200, 400 (params required), or 404 (trace not found) — not 401/403
 ```
 
+### Loki write — gRPC OTLP
+
+Backend: `loki-distributor:9095`. Separate `GRPCRoute` — bypasses `loki-gateway` (nginx does not handle gRPC).
+
+> **Note on missing `X-Scope-OrgID`**: `GRPCRoute` does not support `HTTPRouteFilter` via `ExtensionRef`, so requests missing `X-Scope-OrgID` get a no-route rejection rather than a strict 401.
+
+```bash
+# Valid auth — request reaches Loki, grpc-status: 12 (UNIMPLEMENTED) confirms routing succeeded
+curl -si --http2 -X POST "https://$GRPC_HOST/opentelemetry.proto.collector.logs.v1.LogsService/Export" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "X-Scope-OrgID: $ORG" \
+  -H "Content-Type: application/grpc" \
+  --data-binary $'\x00\x00\x00\x00\x00'
+# expect: grpc-status: 12 (not 16)
+
+# No JWT — SecurityPolicy returns grpc-status: 16 (UNAUTHENTICATED)
+curl -si --http2 -X POST "https://$GRPC_HOST/opentelemetry.proto.collector.logs.v1.LogsService/Export" \
+  -H "X-Scope-OrgID: $ORG" \
+  -H "Content-Type: application/grpc" \
+  --data-binary $'\x00\x00\x00\x00\x00'
+# expect: grpc-status: 16
+```
+
 ### Tempo read — gRPC
 
-Backend: `tempo-query-frontend:9095`. Separate HTTPRoute from the HTTP routes above.
+Backend: `tempo-query-frontend:9095`. Separate `GRPCRoute` from the HTTP routes above.
 
 > **Note on GRPCRoute**: The gRPC route uses `GRPCRoute` (not `HTTPRoute`) because Envoy
 > Gateway's SecurityPolicy JWT enforcement does not correctly apply to gRPC traffic routed
@@ -300,11 +323,11 @@ kubectl get securitypolicy -A
 # All policies should show ACCEPTED=True
 
 RELEASE="observability-platform-api"
+# One consolidated SecurityPolicy per service for Loki and Mimir (covers all routes in that namespace).
+# Tempo has separate policies per route because the GRPCRoute requires its own targetRef.
 for NS_NAME in \
-  "loki/$RELEASE-loki-read-api" \
-  "loki/$RELEASE-loki-write-api" \
-  "mimir/$RELEASE-mimir-read-api" \
-  "mimir/$RELEASE-mimir-write-api" \
+  "loki/$RELEASE-loki" \
+  "mimir/$RELEASE-mimir" \
   "tempo/$RELEASE-tempo-read-api" \
   "tempo/$RELEASE-tempo-read-api-grpc" \
   "tempo/$RELEASE-tempo-otlp-write-api"; do

--- a/TESTING.md
+++ b/TESTING.md
@@ -322,7 +322,7 @@ curl -si --http2 -X POST "https://$GRPC_HOST/tempopb.StreamingQuerier/SearchTags
 
 ### Tempo OTLP write
 
-Backend: `tempo-distributor:4318`. OTLP HTTP only — no gRPC write route (matches old NGINX config).
+Backend: `tempo-distributor:4318`. OTLP HTTP trace ingestion.
 
 ```bash
 curl -si -X POST "$BASE/v1/traces" \
@@ -338,6 +338,28 @@ curl -si -X POST "$BASE/v1/traces" \
 curl -si -X POST "$BASE/v1/traces" \
   -H "$SCOPE" -H "Content-Type: application/json" -d '{}'
 # expect: 401
+```
+
+### Tempo write — gRPC OTLP
+
+Backend: `tempo-distributor:4317`. Separate `GRPCRoute` — routes directly to `tempo-distributor` (nginx does not handle gRPC).
+
+> **Note on missing `X-Scope-OrgID`**: `GRPCRoute` does not support `HTTPRouteFilter` via `ExtensionRef`, so requests missing `X-Scope-OrgID` get a no-route rejection rather than a strict 401.
+
+```bash
+# With auth and X-Scope-OrgID — reaches backend
+grpcurl -H "Authorization: Bearer $TOKEN" \
+  -H "X-Scope-OrgID: $ORG" \
+  "$GRPC_HOST:443" \
+  opentelemetry.proto.collector.trace.v1.TraceService/Export
+# expect: response from tempo-distributor (grpc-status: 0 or similar — not 16)
+
+# No JWT — SecurityPolicy returns grpc-status: 16 (UNAUTHENTICATED)
+curl -si --http2 -X POST "https://$GRPC_HOST/opentelemetry.proto.collector.trace.v1.TraceService/Export" \
+  -H "X-Scope-OrgID: $ORG" \
+  -H "Content-Type: application/grpc" \
+  --data-binary $'\x00\x00\x00\x00\x00'
+# expect: grpc-status: 16
 ```
 
 ## 5. Verify SecurityPolicy status in-cluster
@@ -356,7 +378,8 @@ for NS_NAME in \
   "mimir/$RELEASE-mimir" \
   "tempo/$RELEASE-tempo-read-api" \
   "tempo/$RELEASE-tempo-read-api-grpc" \
-  "tempo/$RELEASE-tempo-otlp-write-api"; do
+  "tempo/$RELEASE-tempo-otlp-write-api" \
+  "tempo/$RELEASE-tempo-write-api-grpc"; do
   NS=$(echo $NS_NAME | cut -d/ -f1)
   NAME=$(echo $NS_NAME | cut -d/ -f2)
   STATUS=$(kubectl get securitypolicy -n $NS $NAME -o json 2>/dev/null \

--- a/TESTING.md
+++ b/TESTING.md
@@ -127,7 +127,7 @@ GRPC_HOST="${BASE#https://}"
 # For Basic Auth testing — username is the MC name, password from section 2b above
 BASIC_USER="<mc-name>"  # e.g. graveler
 BASIC_PASS="<password from org-giantswarm secret>"
-BASIC_AUTH="Authorization: Basic $(echo -n "$BASIC_USER:$BASIC_PASS" | base64)"
+BASIC_AUTH="Authorization: Basic $(echo -n "$BASIC_USER:$BASIC_PASS" | base64 -w0)"
 ```
 
 ## 4. Test all paths

--- a/helm/observability-platform-api/ci/test-values.yaml
+++ b/helm/observability-platform-api/ci/test-values.yaml
@@ -15,6 +15,18 @@ loki:
     namespace: envoy-gateway-system
   basicAuth:
     secretName: "loki-basic-auth"
+  read:
+    paths:
+    - /loki/api/v1/labels
+    - /loki/api/v1/query
+  write:
+    paths:
+    - /loki/api/v1/push
+    - /otlp/v1/logs
+    stripPrefixPaths: []
+    grpc:
+      backendService: loki-distributor
+      backendPort: 9095
 
 mimir:
   enabled: true
@@ -25,6 +37,15 @@ mimir:
     namespace: envoy-gateway-system
   basicAuth:
     secretName: "mimir-basic-auth"
+  read:
+    paths:
+    - /prometheus/api/v1/labels
+    - /prometheus/api/v1/query
+  write:
+    paths:
+    - /otlp/v1/metrics
+    stripPrefixPaths:
+    - /prometheus/api/v1/push
 
 tempo:
   enabled: true
@@ -35,3 +56,14 @@ tempo:
     namespace: envoy-gateway-system
   basicAuth:
     secretName: "tempo-basic-auth"
+  read:
+    paths:
+    - /tempo/api/echo
+    - /tempo/api/search
+    grpc:
+      backendService: tempo-query-frontend
+      backendPort: 9095
+  write:
+    paths:
+    - /v1/traces
+    stripPrefixPaths: []

--- a/helm/observability-platform-api/ci/test-values.yaml
+++ b/helm/observability-platform-api/ci/test-values.yaml
@@ -25,7 +25,7 @@ loki:
     - /otlp/v1/logs
     stripPrefixPaths: []
     grpc:
-      backendService: loki-distributor
+      backendService: loki-write
       backendPort: 9095
 
 mimir:
@@ -67,3 +67,6 @@ tempo:
     paths:
     - /v1/traces
     stripPrefixPaths: []
+    grpc:
+      backendService: tempo-distributor
+      backendPort: 4317

--- a/helm/observability-platform-api/templates/loki/route-grpc.yaml
+++ b/helm/observability-platform-api/templates/loki/route-grpc.yaml
@@ -1,0 +1,55 @@
+{{/*
+Loki gRPC OTLP write route (loki.enabled=true)
+
+Resources:
+  - GRPCRoute (loki-write-api-grpc): routes gRPC OTLP log ingestion to loki-distributor:9095.
+    Single rule: matches opentelemetry.proto.collector.logs.v1.LogsService + X-Scope-OrgID header
+                 → forwards to backend.
+    Requests missing X-Scope-OrgID do not match and are rejected by Envoy (no route match).
+    Note: GRPCRoute does not support HTTPRouteFilter ExtensionRef, so a directResponse
+    rule cannot be used; missing-header requests get a non-401 rejection instead.
+
+    The route targets loki-distributor directly (not loki-gateway) because the nginx gateway
+    does not handle gRPC traffic.
+
+Exposed gRPC service:
+  opentelemetry.proto.collector.logs.v1.LogsService  (OTLP log ingestion)
+*/}}
+{{- if and .Values.loki.enabled (or .Values.auth.jwt.providers .Values.loki.basicAuth.secretName) -}}
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: GRPCRoute
+metadata:
+  name: {{ include "resource.default.name" . }}-loki-write-api-grpc
+  namespace: {{ .Values.loki.namespace }}
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+spec:
+  {{- with .Values.loki.parentRefs }}
+  parentRefs:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.loki.hostname }}
+  hostnames:
+  - {{ tpl . $ | quote }}
+  {{- end }}
+  rules:
+  - backendRefs:
+    - name: {{ .Values.loki.write.grpc.backendService }}
+      namespace: {{ .Values.loki.namespace }}
+      port: {{ .Values.loki.write.grpc.backendPort }}
+    matches:
+    - method:
+        service: opentelemetry.proto.collector.logs.v1.LogsService
+        type: Exact
+      headers:
+      - name: X-Scope-OrgID
+        value: "^.+$"
+        type: RegularExpression
+    filters:
+    - type: ResponseHeaderModifier
+      responseHeaderModifier:
+        set:
+        - name: X-Scope-OrgID
+          value: "%REQ(X-Scope-OrgID)%"
+{{- end }}

--- a/helm/observability-platform-api/templates/loki/route-grpc.yaml
+++ b/helm/observability-platform-api/templates/loki/route-grpc.yaml
@@ -9,8 +9,9 @@ Resources:
     Note: GRPCRoute does not support HTTPRouteFilter ExtensionRef, so a directResponse
     rule cannot be used; missing-header requests get a non-401 rejection instead.
 
-    The route targets loki-distributor directly (not loki-gateway) because the nginx gateway
-    does not handle gRPC traffic.
+    The route targets the Loki write component directly (not loki-gateway) because the nginx
+    gateway does not handle gRPC traffic. In SimpleScalable mode this is loki-write; in
+    microservices mode this is loki-distributor.
 
 Exposed gRPC service:
   opentelemetry.proto.collector.logs.v1.LogsService  (OTLP log ingestion)

--- a/helm/observability-platform-api/templates/loki/route-read.yaml
+++ b/helm/observability-platform-api/templates/loki/route-read.yaml
@@ -35,7 +35,7 @@ spec:
       namespace: {{ .Values.loki.namespace }}
       port: 80
     matches:
-    {{- range .Values.loki.readPaths }}
+    {{- range .Values.loki.read.paths }}
     - path:
         type: PathPrefix
         value: {{ . }}
@@ -61,7 +61,7 @@ spec:
         kind: HTTPRouteFilter
         name: {{ include "resource.default.name" . }}-loki-headers-check
     matches:
-    {{- range .Values.loki.readPaths }}
+    {{- range .Values.loki.read.paths }}
     - path:
         type: PathPrefix
         value: {{ . }}

--- a/helm/observability-platform-api/templates/loki/route-write.yaml
+++ b/helm/observability-platform-api/templates/loki/route-write.yaml
@@ -30,7 +30,7 @@ spec:
   - {{ tpl . $ | quote }}
   {{- end }}
   rules:
-  {{- range .Values.loki.writePaths }}
+  {{- range .Values.loki.write.paths }}
   - backendRefs:
     - name: loki-gateway
       namespace: {{ $.Values.loki.namespace }}

--- a/helm/observability-platform-api/templates/loki/securitypolicy.yaml
+++ b/helm/observability-platform-api/templates/loki/securitypolicy.yaml
@@ -21,6 +21,9 @@ spec:
   - group: gateway.networking.k8s.io
     kind: HTTPRoute
     name: {{ include "resource.default.name" . }}-loki-write-api
+  - group: gateway.networking.k8s.io
+    kind: GRPCRoute
+    name: {{ include "resource.default.name" . }}-loki-write-api-grpc
   {{- if .Values.auth.jwt.providers }}
   jwt:
     providers:

--- a/helm/observability-platform-api/templates/loki/securitypolicy.yaml
+++ b/helm/observability-platform-api/templates/loki/securitypolicy.yaml
@@ -26,6 +26,9 @@ spec:
     name: {{ include "resource.default.name" . }}-loki-write-api-grpc
   {{- if .Values.auth.jwt.providers }}
   jwt:
+    {{- if .Values.loki.basicAuth.secretName }}
+    optional: true
+    {{- end }}
     providers:
       {{- toYaml .Values.auth.jwt.providers | nindent 6 }}
   {{- end }}

--- a/helm/observability-platform-api/templates/mimir/route-read.yaml
+++ b/helm/observability-platform-api/templates/mimir/route-read.yaml
@@ -36,7 +36,7 @@ spec:
       namespace: {{ .Values.mimir.namespace }}
       port: 80
     matches:
-    {{- range .Values.mimir.readPaths }}
+    {{- range .Values.mimir.read.paths }}
     - path:
         type: PathPrefix
         value: {{ . }}
@@ -62,7 +62,7 @@ spec:
         kind: HTTPRouteFilter
         name: {{ include "resource.default.name" . }}-mimir-headers-check
     matches:
-    {{- range .Values.mimir.readPaths }}
+    {{- range .Values.mimir.read.paths }}
     - path:
         type: PathPrefix
         value: {{ . }}

--- a/helm/observability-platform-api/templates/mimir/route-write.yaml
+++ b/helm/observability-platform-api/templates/mimir/route-write.yaml
@@ -34,7 +34,7 @@ spec:
   - {{ tpl . $ | quote }}
   {{- end }}
   rules:
-  {{- range .Values.mimir.writeRewritePaths }}
+  {{- range .Values.mimir.write.stripPrefixPaths }}
   - backendRefs:
     - name: mimir-gateway
       namespace: {{ $.Values.mimir.namespace }}
@@ -73,7 +73,7 @@ spec:
         type: PathPrefix
         value: {{ . }}
   {{- end }}
-  {{- range .Values.mimir.writePassthroughPaths }}
+  {{- range .Values.mimir.write.paths }}
   - backendRefs:
     - name: mimir-gateway
       namespace: {{ $.Values.mimir.namespace }}

--- a/helm/observability-platform-api/templates/mimir/securitypolicy.yaml
+++ b/helm/observability-platform-api/templates/mimir/securitypolicy.yaml
@@ -23,6 +23,9 @@ spec:
     name: {{ include "resource.default.name" . }}-mimir-write-api
   {{- if .Values.auth.jwt.providers }}
   jwt:
+    {{- if .Values.mimir.basicAuth.secretName }}
+    optional: true
+    {{- end }}
     providers:
       {{- toYaml .Values.auth.jwt.providers | nindent 6 }}
   {{- end }}

--- a/helm/observability-platform-api/templates/tempo/route-grpc.yaml
+++ b/helm/observability-platform-api/templates/tempo/route-grpc.yaml
@@ -31,9 +31,9 @@ spec:
   {{- end }}
   rules:
   - backendRefs:
-    - name: tempo-query-frontend
+    - name: {{ .Values.tempo.read.grpc.backendService }}
       namespace: {{ .Values.tempo.namespace }}
-      port: 9095
+      port: {{ .Values.tempo.read.grpc.backendPort }}
     matches:
     - method:
         service: "tempopb\\.[^/]+"

--- a/helm/observability-platform-api/templates/tempo/route-grpc.yaml
+++ b/helm/observability-platform-api/templates/tempo/route-grpc.yaml
@@ -1,15 +1,21 @@
 {{/*
-Tempo gRPC read route (tempo.enabled=true)
+Tempo gRPC routes (tempo.enabled=true)
 
 Resources:
-  - GRPCRoute (tempo-read-api-grpc): routes gRPC requests to tempo-query-frontend:9095.
+  - GRPCRoute (tempo-read-api-grpc): routes gRPC read requests to tempo-query-frontend:9095.
     Single rule: matches tempopb.* service + X-Scope-OrgID header → forwards to backend.
     Requests missing X-Scope-OrgID do not match and are rejected by Envoy (no route match).
     Note: GRPCRoute does not support HTTPRouteFilter ExtensionRef, so a directResponse
     rule cannot be used; missing-header requests get a non-401 rejection instead.
 
-Exposed gRPC path:
-  any service matching regex "tempopb\.[^/]+"  (e.g. tempopb.StreamingQuerier, tempopb.Querier)
+  - GRPCRoute (tempo-write-api-grpc): routes OTLP gRPC trace ingestion to tempo-distributor:4317.
+    Single rule: matches opentelemetry.proto.collector.trace.v1.TraceService + X-Scope-OrgID
+    header → forwards to backend. Routes directly to tempo-distributor (bypasses the nginx
+    gateway, which does not handle gRPC).
+
+Exposed gRPC paths:
+  Read:  any service matching regex "tempopb\.[^/]+"  (e.g. tempopb.StreamingQuerier, tempopb.Querier)
+  Write: opentelemetry.proto.collector.trace.v1.TraceService  (OTLP gRPC trace ingestion)
 */}}
 {{- if and .Values.tempo.enabled (or .Values.auth.jwt.providers .Values.tempo.basicAuth.secretName) -}}
 ---
@@ -38,6 +44,42 @@ spec:
     - method:
         service: "tempopb\\.[^/]+"
         type: RegularExpression
+      headers:
+      - name: X-Scope-OrgID
+        value: "^.+$"
+        type: RegularExpression
+    filters:
+    - type: ResponseHeaderModifier
+      responseHeaderModifier:
+        set:
+        - name: X-Scope-OrgID
+          value: "%REQ(X-Scope-OrgID)%"
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: GRPCRoute
+metadata:
+  name: {{ include "resource.default.name" . }}-tempo-write-api-grpc
+  namespace: {{ .Values.tempo.namespace }}
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+spec:
+  {{- with .Values.tempo.parentRefs }}
+  parentRefs:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.tempo.hostname }}
+  hostnames:
+  - {{ tpl . $ | quote }}
+  {{- end }}
+  rules:
+  - backendRefs:
+    - name: {{ .Values.tempo.write.grpc.backendService }}
+      namespace: {{ .Values.tempo.namespace }}
+      port: {{ .Values.tempo.write.grpc.backendPort }}
+    matches:
+    - method:
+        service: opentelemetry.proto.collector.trace.v1.TraceService
+        type: Exact
       headers:
       - name: X-Scope-OrgID
         value: "^.+$"

--- a/helm/observability-platform-api/templates/tempo/route-read.yaml
+++ b/helm/observability-platform-api/templates/tempo/route-read.yaml
@@ -34,7 +34,7 @@ spec:
       namespace: {{ .Values.tempo.namespace }}
       port: 3200
     matches:
-    {{- range .Values.tempo.readPaths }}
+    {{- range .Values.tempo.read.paths }}
     - path:
         type: PathPrefix
         value: {{ . }}
@@ -65,7 +65,7 @@ spec:
         kind: HTTPRouteFilter
         name: {{ include "resource.default.name" . }}-tempo-headers-check
     matches:
-    {{- range .Values.tempo.readPaths }}
+    {{- range .Values.tempo.read.paths }}
     - path:
         type: PathPrefix
         value: {{ . }}

--- a/helm/observability-platform-api/templates/tempo/route-write.yaml
+++ b/helm/observability-platform-api/templates/tempo/route-write.yaml
@@ -29,7 +29,7 @@ spec:
   - {{ tpl . $ | quote }}
   {{- end }}
   rules:
-  {{- range .Values.tempo.writePaths }}
+  {{- range .Values.tempo.write.paths }}
   - backendRefs:
     - name: tempo-distributor
       namespace: {{ $.Values.tempo.namespace }}

--- a/helm/observability-platform-api/templates/tempo/securitypolicy.yaml
+++ b/helm/observability-platform-api/templates/tempo/securitypolicy.yaml
@@ -23,6 +23,9 @@ spec:
     name: {{ include "resource.default.name" . }}-tempo-read-api
   {{- if .Values.auth.jwt.providers }}
   jwt:
+    {{- if .Values.tempo.basicAuth.secretName }}
+    optional: true
+    {{- end }}
     providers:
       {{- toYaml .Values.auth.jwt.providers | nindent 6 }}
   {{- end }}
@@ -46,6 +49,9 @@ spec:
     name: {{ include "resource.default.name" . }}-tempo-read-api-grpc
   {{- if .Values.auth.jwt.providers }}
   jwt:
+    {{- if .Values.tempo.basicAuth.secretName }}
+    optional: true
+    {{- end }}
     providers:
       {{- toYaml .Values.auth.jwt.providers | nindent 6 }}
   {{- end }}
@@ -69,6 +75,9 @@ spec:
     name: {{ include "resource.default.name" . }}-tempo-otlp-write-api
   {{- if .Values.auth.jwt.providers }}
   jwt:
+    {{- if .Values.tempo.basicAuth.secretName }}
+    optional: true
+    {{- end }}
     providers:
       {{- toYaml .Values.auth.jwt.providers | nindent 6 }}
   {{- end }}
@@ -92,6 +101,9 @@ spec:
     name: {{ include "resource.default.name" . }}-tempo-write-api-grpc
   {{- if .Values.auth.jwt.providers }}
   jwt:
+    {{- if .Values.tempo.basicAuth.secretName }}
+    optional: true
+    {{- end }}
     providers:
       {{- toYaml .Values.auth.jwt.providers | nindent 6 }}
   {{- end }}

--- a/helm/observability-platform-api/templates/tempo/securitypolicy.yaml
+++ b/helm/observability-platform-api/templates/tempo/securitypolicy.yaml
@@ -5,6 +5,7 @@ Resources:
   - SecurityPolicy (tempo-read-api): enforces JWT and/or Basic Auth on the tempo-read-api HTTPRoute.
   - SecurityPolicy (tempo-read-api-grpc): enforces JWT and/or Basic Auth on the tempo-read-api-grpc GRPCRoute.
   - SecurityPolicy (tempo-otlp-write-api): enforces JWT and/or Basic Auth on the tempo-otlp-write-api HTTPRoute.
+  - SecurityPolicy (tempo-write-api-grpc): enforces JWT and/or Basic Auth on the tempo-write-api-grpc GRPCRoute.
 */}}
 {{- if and .Values.tempo.enabled (or .Values.auth.jwt.providers .Values.tempo.basicAuth.secretName) -}}
 ---
@@ -66,6 +67,29 @@ spec:
   - group: gateway.networking.k8s.io
     kind: HTTPRoute
     name: {{ include "resource.default.name" . }}-tempo-otlp-write-api
+  {{- if .Values.auth.jwt.providers }}
+  jwt:
+    providers:
+      {{- toYaml .Values.auth.jwt.providers | nindent 6 }}
+  {{- end }}
+  {{- if .Values.tempo.basicAuth.secretName }}
+  basicAuth:
+    users:
+      name: {{ .Values.tempo.basicAuth.secretName }}
+  {{- end }}
+---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: {{ include "resource.default.name" . }}-tempo-write-api-grpc
+  namespace: {{ .Values.tempo.namespace }}
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+spec:
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: GRPCRoute
+    name: {{ include "resource.default.name" . }}-tempo-write-api-grpc
   {{- if .Values.auth.jwt.providers }}
   jwt:
     providers:

--- a/helm/observability-platform-api/values.schema.json
+++ b/helm/observability-platform-api/values.schema.json
@@ -27,15 +27,25 @@
                         }
                     }
                 },
-                "readPaths": {
-                    "type": "array",
-                    "description": "Paths exposed on the Loki read route, matched with PathPrefix.",
-                    "items": { "type": "string" }
+                "read": {
+                    "type": "object",
+                    "properties": {
+                        "paths": { "type": "array", "items": { "type": "string" } }
+                    }
                 },
-                "writePaths": {
-                    "type": "array",
-                    "description": "Paths exposed on the Loki write route, forwarded as-is.",
-                    "items": { "type": "string" }
+                "write": {
+                    "type": "object",
+                    "properties": {
+                        "paths": { "type": "array", "items": { "type": "string" } },
+                        "stripPrefixPaths": { "type": "array", "items": { "type": "string" } },
+                        "grpc": {
+                            "type": "object",
+                            "properties": {
+                                "backendService": { "type": "string" },
+                                "backendPort": { "type": "integer" }
+                            }
+                        }
+                    }
                 }
             }
         },
@@ -64,20 +74,18 @@
                         }
                     }
                 },
-                "readPaths": {
-                    "type": "array",
-                    "description": "Paths exposed on the Mimir read route, matched with PathPrefix.",
-                    "items": { "type": "string" }
+                "read": {
+                    "type": "object",
+                    "properties": {
+                        "paths": { "type": "array", "items": { "type": "string" } }
+                    }
                 },
-                "writeRewritePaths": {
-                    "type": "array",
-                    "description": "Paths forwarded to Mimir with the /prometheus prefix stripped.",
-                    "items": { "type": "string" }
-                },
-                "writePassthroughPaths": {
-                    "type": "array",
-                    "description": "Paths forwarded to Mimir as-is (no rewrite). Used for OTLP ingestion.",
-                    "items": { "type": "string" }
+                "write": {
+                    "type": "object",
+                    "properties": {
+                        "paths": { "type": "array", "items": { "type": "string" } },
+                        "stripPrefixPaths": { "type": "array", "items": { "type": "string" } }
+                    }
                 }
             }
         },
@@ -106,15 +114,25 @@
                         }
                     }
                 },
-                "readPaths": {
-                    "type": "array",
-                    "description": "Paths exposed on the Tempo read route, forwarded with the /tempo prefix stripped.",
-                    "items": { "type": "string" }
+                "read": {
+                    "type": "object",
+                    "properties": {
+                        "paths": { "type": "array", "items": { "type": "string" } },
+                        "grpc": {
+                            "type": "object",
+                            "properties": {
+                                "backendService": { "type": "string" },
+                                "backendPort": { "type": "integer" }
+                            }
+                        }
+                    }
                 },
-                "writePaths": {
-                    "type": "array",
-                    "description": "Paths exposed on the Tempo OTLP write route, forwarded as-is.",
-                    "items": { "type": "string" }
+                "write": {
+                    "type": "object",
+                    "properties": {
+                        "paths": { "type": "array", "items": { "type": "string" } },
+                        "stripPrefixPaths": { "type": "array", "items": { "type": "string" } }
+                    }
                 }
             }
         },

--- a/helm/observability-platform-api/values.schema.json
+++ b/helm/observability-platform-api/values.schema.json
@@ -212,6 +212,24 @@
                                                 "type": "string"
                                             }
                                         }
+                                    },
+                                    "extractFrom": {
+                                        "type": "object",
+                                        "description": "Restrict where the JWT is extracted from. Best practice: set headers[].valuePrefix to 'Bearer ' so that Basic Auth credentials on the Authorization header are not mistakenly parsed as a JWT.",
+                                        "properties": {
+                                            "headers": {
+                                                "type": "array",
+                                                "items": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "name": { "type": "string" },
+                                                        "valuePrefix": { "type": "string" }
+                                                    }
+                                                }
+                                            },
+                                            "cookies": { "type": "array", "items": { "type": "string" } },
+                                            "params": { "type": "array", "items": { "type": "string" } }
+                                        }
                                     }
                                 }
                             }

--- a/helm/observability-platform-api/values.schema.json
+++ b/helm/observability-platform-api/values.schema.json
@@ -131,7 +131,14 @@
                     "type": "object",
                     "properties": {
                         "paths": { "type": "array", "items": { "type": "string" } },
-                        "stripPrefixPaths": { "type": "array", "items": { "type": "string" } }
+                        "stripPrefixPaths": { "type": "array", "items": { "type": "string" } },
+                        "grpc": {
+                            "type": "object",
+                            "properties": {
+                                "backendService": { "type": "string" },
+                                "backendPort": { "type": "integer" }
+                            }
+                        }
                     }
                 }
             }

--- a/helm/observability-platform-api/values.yaml
+++ b/helm/observability-platform-api/values.yaml
@@ -22,85 +22,106 @@ auth:
 loki:
   enabled: false
   namespace: loki
-  # -- Hostname for all Loki routes. Supports Helm template strings.
   hostname: ""
   parentRefs:
   - name: giantswarm-default
     namespace: envoy-gateway-system
   basicAuth:
-    # -- Name of a Kubernetes Secret with .htpasswd-formatted credentials in the loki namespace.
-    # When set alongside auth.jwt.providers, routes accept either Basic Auth or JWT.
     secretName: ""
-  # -- Paths exposed on the Loki read route. Each path is matched with PathPrefix.
-  readPaths:
-  - /loki/api/v1/labels
-  - /loki/api/v1/label
-  - /loki/api/v1/rules
-  - /loki/api/v1/query
-  - /loki/api/v1/index
-  - /loki/api/v1/query_range
-  - /loki/api/v1/series
-  - /loki/api/v1/detected_labels
-  # -- Paths exposed on the Loki write route. Each path is matched with PathPrefix and forwarded as-is.
-  writePaths:
-  - /loki/api/v1/push
-  - /otlp/v1/logs
+  # -- HTTP read route configuration.
+  read:
+    # -- Paths exposed on the Loki read route. Each matched with PathPrefix and forwarded as-is to loki-gateway:80.
+    paths:
+    - /loki/api/v1/labels
+    - /loki/api/v1/label
+    - /loki/api/v1/rules
+    - /loki/api/v1/query
+    - /loki/api/v1/index
+    - /loki/api/v1/query_range
+    - /loki/api/v1/series
+    - /loki/api/v1/detected_labels
+  # -- HTTP write route configuration.
+  write:
+    # -- Paths forwarded as-is to loki-gateway:80.
+    paths:
+    - /loki/api/v1/push
+    - /otlp/v1/logs
+    # -- Paths whose leading prefix is stripped before forwarding (e.g. /loki/api/v1/push → /api/v1/push).
+    # Leave empty for Loki — loki-gateway handles the /loki prefix natively.
+    stripPrefixPaths: []
+    # -- gRPC OTLP ingestion. Routes directly to loki-distributor (bypasses the nginx gateway,
+    # which does not handle gRPC). Set backendService/backendPort to enable.
+    grpc:
+      backendService: loki-distributor
+      backendPort: 9095
 
 mimir:
   enabled: false
   namespace: mimir
-  # -- Hostname for all Mimir routes. Supports Helm template strings.
   hostname: ""
   parentRefs:
   - name: giantswarm-default
     namespace: envoy-gateway-system
   basicAuth:
-    # -- Name of a Kubernetes Secret with .htpasswd-formatted credentials in the mimir namespace.
-    # When set alongside auth.jwt.providers, routes accept either Basic Auth or JWT.
     secretName: ""
-  # -- Paths exposed on the Mimir read route. Each path is matched with PathPrefix.
-  readPaths:
-  - /prometheus/api/v1/labels
-  - /prometheus/api/v1/label
-  - /prometheus/api/v1/rules
-  - /prometheus/api/v1/query
-  - /prometheus/api/v1/query_exemplars
-  - /prometheus/api/v1/query_range
-  - /prometheus/api/v1/status
-  - /prometheus/api/v1/metadata
-  - /prometheus/api/v1/detected_labels
-  # -- Paths forwarded to Mimir with the /prometheus prefix stripped (e.g. /prometheus/api/v1/push → /api/v1/push).
-  writeRewritePaths:
-  - /prometheus/api/v1/push
-  # -- Paths forwarded to Mimir as-is (no rewrite). Used for OTLP ingestion.
-  writePassthroughPaths:
-  - /otlp/v1/metrics
+  # -- HTTP read route configuration.
+  read:
+    # -- Paths exposed on the Mimir read route. Each matched with PathPrefix and forwarded as-is to mimir-gateway:80.
+    paths:
+    - /prometheus/api/v1/labels
+    - /prometheus/api/v1/label
+    - /prometheus/api/v1/rules
+    - /prometheus/api/v1/query
+    - /prometheus/api/v1/query_exemplars
+    - /prometheus/api/v1/query_range
+    - /prometheus/api/v1/status
+    - /prometheus/api/v1/metadata
+    - /prometheus/api/v1/detected_labels
+  # -- HTTP write route configuration.
+  write:
+    # -- Paths forwarded as-is to mimir-gateway:80 (OTLP ingestion).
+    paths:
+    - /otlp/v1/metrics
+    # -- Paths whose leading /prometheus prefix is stripped before forwarding to mimir-gateway:80.
+    # Required because mimir-gateway's nginx routes remote_write at /api/v1/push (no /prometheus prefix),
+    # while the external API convention is /prometheus/api/v1/push.
+    stripPrefixPaths:
+    - /prometheus/api/v1/push
 
 tempo:
   enabled: false
   namespace: tempo
-  # -- Hostname for all Tempo routes. Supports Helm template strings.
   hostname: ""
   parentRefs:
   - name: giantswarm-default
     namespace: envoy-gateway-system
   basicAuth:
-    # -- Name of a Kubernetes Secret with .htpasswd-formatted credentials in the tempo namespace.
-    # When set alongside auth.jwt.providers, routes accept either Basic Auth or JWT.
     secretName: ""
-  # -- Paths exposed on the Tempo read route. Each path is matched with PathPrefix and forwarded
-  # with the /tempo prefix stripped (e.g. /tempo/api/echo → /api/echo).
-  readPaths:
-  - /tempo/api/echo
-  - /tempo/api/status/buildinfo
-  - /tempo/api/metrics/query_range
-  - /tempo/api/search
-  - /tempo/api/v2/search
-  - /tempo/api/traces
-  - /tempo/api/v2/traces
-  # -- Paths exposed on the Tempo OTLP write route. Each path is matched with PathPrefix and forwarded as-is.
-  writePaths:
-  - /v1/traces
+  # -- HTTP read route configuration.
+  read:
+    # -- Paths exposed on the Tempo read route. Each matched with PathPrefix.
+    # The /tempo prefix is stripped before forwarding to tempo-query-frontend:3200
+    # (all paths in this list are subject to the prefix-strip rewrite).
+    paths:
+    - /tempo/api/echo
+    - /tempo/api/status/buildinfo
+    - /tempo/api/metrics/query_range
+    - /tempo/api/search
+    - /tempo/api/v2/search
+    - /tempo/api/traces
+    - /tempo/api/v2/traces
+    # -- gRPC read queries. Routes to tempo-query-frontend:9095.
+    # Matches any gRPC service matching regex "tempopb\.[^/]+".
+    grpc:
+      backendService: tempo-query-frontend
+      backendPort: 9095
+  # -- HTTP write route configuration.
+  write:
+    # -- Paths forwarded as-is to tempo-distributor:4318 (OTLP HTTP trace ingestion).
+    paths:
+    - /v1/traces
+    # -- No prefix stripping needed for Tempo write paths.
+    stripPrefixPaths: []
 
 ingresses:
   - name: loki

--- a/helm/observability-platform-api/values.yaml
+++ b/helm/observability-platform-api/values.yaml
@@ -122,6 +122,11 @@ tempo:
     - /v1/traces
     # -- No prefix stripping needed for Tempo write paths.
     stripPrefixPaths: []
+    # -- gRPC OTLP trace ingestion. Routes directly to tempo-distributor:4317 (bypasses the nginx
+    # gateway, which does not handle gRPC). Set backendService/backendPort to enable.
+    grpc:
+      backendService: tempo-distributor
+      backendPort: 4317
 
 ingresses:
   - name: loki

--- a/helm/observability-platform-api/values.yaml
+++ b/helm/observability-platform-api/values.yaml
@@ -14,10 +14,21 @@ auth:
     #   issuer: "https://dex.mycluster.example.com"
     #   remoteJWKS:
     #     uri: "https://dex.mycluster.example.com/keys"
+    #   # Best practice: restrict JWT extraction to Bearer tokens only.
+    #   # This prevents the JWT filter from attempting to parse Basic Auth credentials
+    #   # as a JWT when both auth methods are enabled on the same route.
+    #   extractFrom:
+    #     headers:
+    #     - name: Authorization
+    #       valuePrefix: "Bearer "
     # - name: azure-ad
     #   issuer: "https://login.microsoftonline.com/<tenant-id>/v2.0"
     #   remoteJWKS:
     #     uri: "https://login.microsoftonline.com/<tenant-id>/discovery/v2.0/keys"
+    #   extractFrom:
+    #     headers:
+    #     - name: Authorization
+    #       valuePrefix: "Bearer "
 
 loki:
   enabled: false
@@ -56,10 +67,11 @@ loki:
     # -- Paths whose leading prefix is stripped before forwarding (e.g. /loki/api/v1/push → /api/v1/push).
     # Leave empty for Loki — loki-gateway handles the /loki prefix natively.
     stripPrefixPaths: []
-    # -- gRPC OTLP ingestion. Routes directly to loki-distributor (bypasses the nginx gateway,
-    # which does not handle gRPC). Set backendService/backendPort to enable.
+    # -- gRPC OTLP ingestion. Routes directly to the Loki write component (bypasses the nginx
+    # gateway, which does not handle gRPC). Set backendService/backendPort to enable.
+    # Use loki-write for SimpleScalable mode (default); loki-distributor for microservices mode.
     grpc:
-      backendService: loki-distributor
+      backendService: loki-write
       backendPort: 9095
 
 mimir:

--- a/helm/observability-platform-api/values.yaml
+++ b/helm/observability-platform-api/values.yaml
@@ -40,6 +40,13 @@ loki:
     - /loki/api/v1/query_range
     - /loki/api/v1/series
     - /loki/api/v1/detected_labels
+    - /loki/api/v1/tail
+    - /loki/api/v1/format_query
+    - /loki/api/v1/index/stats
+    - /loki/api/v1/index/volume
+    - /loki/api/v1/index/volume_range
+    - /loki/api/v1/detected_fields
+    - /loki/api/v1/patterns
   # -- HTTP write route configuration.
   write:
     # -- Paths forwarded as-is to loki-gateway:80.
@@ -74,6 +81,7 @@ mimir:
     - /prometheus/api/v1/query
     - /prometheus/api/v1/query_exemplars
     - /prometheus/api/v1/query_range
+    - /prometheus/api/v1/series
     - /prometheus/api/v1/status
     - /prometheus/api/v1/metadata
     - /prometheus/api/v1/detected_labels
@@ -107,7 +115,10 @@ tempo:
     - /tempo/api/status/buildinfo
     - /tempo/api/metrics/query_range
     - /tempo/api/search
+    - /tempo/api/search/tags
     - /tempo/api/v2/search
+    - /tempo/api/v2/search/tags
+    - /tempo/api/v2/search/tag/
     - /tempo/api/traces
     - /tempo/api/v2/traces
     # -- gRPC read queries. Routes to tempo-query-frontend:9095.


### PR DESCRIPTION
## Summary

- **Loki gRPC OTLP**: Adds a `GRPCRoute` for OpenTelemetry log ingestion via gRPC (`opentelemetry.proto.collector.logs.v1.LogsService`), routed directly to `loki-distributor:9095`. The nginx gateway (`loki-gateway`) does not handle gRPC, so this route bypasses it. JWT and Basic Auth enforced via the shared Loki `SecurityPolicy`.
- **Consistent values API**: Restructures per-service path config into nested `read`/`write` objects (`loki.read.paths`, `loki.write.paths`, etc.) with a uniform `stripPrefixPaths` field across all backends.
- **Mimir note**: Mimir does not support native gRPC OTLP ingestion (HTTP OTLP only via `mimir.write.paths`). No GRPCRoute added for Mimir.

## Values API changes (breaking)

| Old | New |
|-----|-----|
| `loki.readPaths` | `loki.read.paths` |
| `loki.writePaths` | `loki.write.paths` |
| `loki.otlpGrpc.backendService/Port` | `loki.write.grpc.backendService/Port` |
| `mimir.readPaths` | `mimir.read.paths` |
| `mimir.writePassthroughPaths` | `mimir.write.paths` |
| `mimir.writeRewritePaths` | `mimir.write.stripPrefixPaths` |
| `tempo.readPaths` | `tempo.read.paths` |
| `tempo.writePaths` | `tempo.write.paths` |
| *(hardcoded)* | `tempo.read.grpc.backendService/Port` |

## Test plan

- [x] `helm lint` passes
- [x] `helm template` produces all 20 expected resources including the new `loki-write-api-grpc` GRPCRoute
- [ ] Deploy to test cluster and verify Loki accepts OTLP logs via gRPC with `Authorization: Bearer` and `X-Scope-OrgID` headers

🤖 Generated with [Claude Code](https://claude.com/claude-code)