### PR TITLE
Add loki.write.requestMirror to the Loki write route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `loki.write.requestMirror`, an optional Envoy `RequestMirror` filter on the Loki write route that tees accepted writes to a second backend. Disabled by default; when enabled it is added to the header-matching rule only, so rejected requests are not mirrored.
+
 ## [0.4.0] - 2026-03-24
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add `loki.write.requestMirror`, an optional Envoy `RequestMirror` filter on the Loki write route that tees accepted writes to a second backend. Disabled by default; when enabled it is added to the header-matching rule only, so rejected requests are not mirrored.
+- Add `loki.write.requestMirror`, an optional `RequestMirror` filter on the Loki write route. Disabled by default.
 
 ## [0.4.0] - 2026-03-24
 

--- a/helm/observability-platform-api/templates/loki/route-write.yaml
+++ b/helm/observability-platform-api/templates/loki/route-write.yaml
@@ -59,9 +59,6 @@ spec:
     */}}
     - type: RequestMirror
       requestMirror:
-        {{- with .percent }}
-        percent: {{ . }}
-        {{- end }}
         backendRef:
           {{- toYaml .backendRef | nindent 10 }}
     {{- end }}

--- a/helm/observability-platform-api/templates/loki/route-write.yaml
+++ b/helm/observability-platform-api/templates/loki/route-write.yaml
@@ -49,6 +49,23 @@ spec:
         set:
         - name: X-Scope-OrgID
           value: "%REQ(X-Scope-OrgID)%"
+    {{- with $.Values.loki.write.requestMirror }}
+    {{- if .enabled }}
+    {{- /*
+      Mirror accepted writes to a second backend, fire-and-forget: Envoy always
+      ignores the mirror's response, so this cannot affect the primary path. Only on
+      this rule -- the rule below returns 401 for requests without an X-Scope-OrgID
+      header, and mirroring those would copy only rejected requests.
+    */}}
+    - type: RequestMirror
+      requestMirror:
+        {{- with .percent }}
+        percent: {{ . }}
+        {{- end }}
+        backendRef:
+          {{- toYaml .backendRef | nindent 10 }}
+    {{- end }}
+    {{- end }}
   - backendRefs:
     - name: {{ $.Values.loki.write.backendService }}
       namespace: {{ $.Values.loki.namespace }}

--- a/helm/observability-platform-api/templates/loki/route-write.yaml
+++ b/helm/observability-platform-api/templates/loki/route-write.yaml
@@ -51,12 +51,8 @@ spec:
           value: "%REQ(X-Scope-OrgID)%"
     {{- with $.Values.loki.write.requestMirror }}
     {{- if .enabled }}
-    {{- /*
-      Mirror accepted writes to a second backend, fire-and-forget: Envoy always
-      ignores the mirror's response, so this cannot affect the primary path. Only on
-      this rule -- the rule below returns 401 for requests without an X-Scope-OrgID
-      header, and mirroring those would copy only rejected requests.
-    */}}
+    {{- /* This rule only: the one below returns 401 for requests without an
+           X-Scope-OrgID header, so mirroring it would copy only rejections. */}}
     - type: RequestMirror
       requestMirror:
         backendRef:

--- a/helm/observability-platform-api/values.schema.json
+++ b/helm/observability-platform-api/values.schema.json
@@ -165,6 +165,33 @@
                             "items": {
                                 "type": "string"
                             }
+                        },
+                        "requestMirror": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean"
+                                },
+                                "percent": {
+                                    "type": ["integer", "null"],
+                                    "minimum": 0,
+                                    "maximum": 100
+                                },
+                                "backendRef": {
+                                    "type": "object",
+                                    "properties": {
+                                        "name": {
+                                            "type": "string"
+                                        },
+                                        "namespace": {
+                                            "type": "string"
+                                        },
+                                        "port": {
+                                            "type": "integer"
+                                        }
+                                    }
+                                }
+                            }
                         }
                     }
                 }

--- a/helm/observability-platform-api/values.schema.json
+++ b/helm/observability-platform-api/values.schema.json
@@ -172,11 +172,6 @@
                                 "enabled": {
                                     "type": "boolean"
                                 },
-                                "percent": {
-                                    "type": ["integer", "null"],
-                                    "minimum": 0,
-                                    "maximum": 100
-                                },
                                 "backendRef": {
                                     "type": "object",
                                     "properties": {

--- a/helm/observability-platform-api/values.yaml
+++ b/helm/observability-platform-api/values.yaml
@@ -73,7 +73,11 @@ loki:
       backendService: loki-write
       backendPort: 9095
     # -- Mirror accepted writes to a second backend, fire-and-forget. A cross-namespace
-    # backendRef needs a ReferenceGrant in the target namespace.
+    # backendRef needs a ReferenceGrant in the target namespace; this chart does not
+    # create one. The loki chart's own requestMirror does, and because a grant's
+    # spec.from is namespace-scoped, that single grant also covers this route — both
+    # live in `loki.namespace`. Enabling the mirror here alone leaves the route
+    # ResolvedRefs=False.
     requestMirror:
       enabled: false
       backendRef:

--- a/helm/observability-platform-api/values.yaml
+++ b/helm/observability-platform-api/values.yaml
@@ -72,6 +72,17 @@ loki:
     grpc:
       backendService: loki-write
       backendPort: 9095
+    # -- Mirror accepted writes to a second backend, on top of the normal forward.
+    # Envoy discards the mirror's response, so the primary write path is unaffected.
+    # A ReferenceGrant is required when backendRef is in another namespace.
+    requestMirror:
+      enabled: false
+      # -- Share of requests to mirror, 0-100. Omit for all of them.
+      percent: null
+      backendRef:
+        name: alloy-logexporter
+        namespace: monitoring
+        port: 3100
 
 mimir:
   enabled: false

--- a/helm/observability-platform-api/values.yaml
+++ b/helm/observability-platform-api/values.yaml
@@ -77,8 +77,6 @@ loki:
     # A ReferenceGrant is required when backendRef is in another namespace.
     requestMirror:
       enabled: false
-      # -- Share of requests to mirror, 0-100. Omit for all of them.
-      percent: null
       backendRef:
         name: alloy-logexporter
         namespace: monitoring

--- a/helm/observability-platform-api/values.yaml
+++ b/helm/observability-platform-api/values.yaml
@@ -72,9 +72,8 @@ loki:
     grpc:
       backendService: loki-write
       backendPort: 9095
-    # -- Mirror accepted writes to a second backend, on top of the normal forward.
-    # Envoy discards the mirror's response, so the primary write path is unaffected.
-    # A ReferenceGrant is required when backendRef is in another namespace.
+    # -- Mirror accepted writes to a second backend, fire-and-forget. A cross-namespace
+    # backendRef needs a ReferenceGrant in the target namespace.
     requestMirror:
       enabled: false
       backendRef:


### PR DESCRIPTION
Adds `loki.write.requestMirror`: an optional Envoy `RequestMirror` filter that tees accepted Loki writes to a second backend, for exporting logs out of the platform. Part of [giantswarm/giantswarm#37251](https://github.com/giantswarm/giantswarm/issues/37251). Same value and default as [loki-app#539](https://github.com/giantswarm/loki-app/pull/539), which does the equivalent for the Loki gateway route.

```yaml
loki:
  write:
    requestMirror:
      enabled: false
      backendRef:
        name: alloy-logexporter
        namespace: monitoring
        port: 3100
```

The filter goes on the header-matching rule only. Its sibling matches the same path *without* `X-Scope-OrgID` and returns 401, so mirroring that one would copy only rejected requests.

### The `ReferenceGrant` comes from the loki chart

This chart creates none. [loki-app#539](https://github.com/giantswarm/loki-app/pull/539) does, and a grant's `spec.from` is namespace-scoped, so that one also authorizes this route — both live in `loki.namespace`. Enabling the mirror here alone would leave the route `ResolvedRefs=False`, which the values comment now records.

### Verified

- **Disabled render is byte-identical to `main`.**
- Enabled: the filter lands on the header-matching rule of each write path (`/loki/api/v1/push`, `/otlp/v1/logs`) and nowhere else; the 401 rules keep just their `ExtensionRef`.
- `helm lint` passes and `values.yaml` validates against the updated schema. The grant note is comment-only — the rendered output is unchanged by it.

Rendering only — this route has never served a request on graveler or ferret, so there is nothing live to mirror. It still gets the filter: if a customer starts pushing through the observability API later, their logs would otherwise silently never be exported. The equivalent change on the loki-app route was smoke-tested end to end on graveler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)